### PR TITLE
Fix logging import

### DIFF
--- a/python/aws_lambda_powertools/logging/logger.py
+++ b/python/aws_lambda_powertools/logging/logger.py
@@ -6,7 +6,6 @@ from distutils.util import strtobool
 from typing import Any, Callable, Dict
 
 from . import aws_lambda_logging
-
 from ..helper.models import MetricUnit, build_lambda_context_model, build_metric_unit_from_str
 
 logger = logging.getLogger(__name__)

--- a/python/aws_lambda_powertools/logging/logger.py
+++ b/python/aws_lambda_powertools/logging/logger.py
@@ -5,7 +5,7 @@ import os
 from distutils.util import strtobool
 from typing import Any, Callable, Dict
 
-import aws_lambda_logging
+from . import aws_lambda_logging
 
 from ..helper.models import MetricUnit, build_lambda_context_model, build_metric_unit_from_str
 

--- a/python/tests/functional/test_aws_lambda_logging.py
+++ b/python/tests/functional/test_aws_lambda_logging.py
@@ -113,24 +113,3 @@ def test_with_unserialisable_value_in_message(root_logger, logger, stdout):
     log_dict = json.loads(stdout.getvalue())
 
     assert log_dict["message"]["x"].startswith("<")
-
-
-def test_wrap():
-    from aws_lambda_logging import wrap
-
-    @wrap
-    def handler(event, context):
-        pass
-
-    handler(None, None)
-
-
-def test_wrap_when_request_id_is_in_event():
-    from aws_lambda_logging import wrap
-
-    @wrap
-    def handler(event, context):
-        pass
-
-    event = {"requestContext": {"requestId": "c19e27e6-230b-11e8-ba47-a95ceb1c6480"}}
-    handler(event, None)


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/aws-lambda-powertools/issues/2

*Description of changes:*

* Fix logging import to use the vended version in aws_lambda_powertools.logging.aws_lambda_logging
* Fix test cases to use the vended version instead
* Remove test cases that cover aws_lambda_logging.wrap as wrap is not present in the vended version

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
